### PR TITLE
Switches to MySQL Options files for root credentials

### DIFF
--- a/backup.conf
+++ b/backup.conf
@@ -12,8 +12,7 @@ MinecraftInstalled=0
 
 #MySQL Configuration
 backupMySQL=1
-MYSQLROOTUSER=
-MYSQLROOTPASS=
+MYSQLOPTIONSFILE=  # PATH TO mysql options file with root credentials
 
 #SVN Configuration
 backupSVN=1

--- a/backupIncremental.sh
+++ b/backupIncremental.sh
@@ -83,11 +83,11 @@ if [ $backupMySQL -eq 1 ]
 then
 echo -n "Backing up mysql databases..."
 echo "Backing up  mysql databases..."  >> $BACKUP_DIR/log/backup_$DATES.log
-for i in `mysql -u$MYSQLROOTUSER -p$MYSQLROOTPASS -BNe 'select  schema_name from information_schema.schemata;'`
+for i in `mysql --defaults-file=$MYSQLOPTIONSFILE -BNe 'select  schema_name from information_schema.schemata;'`
 do 
 	BACKUPMODULE="mysql database schema $i"
         echo "Backing up $BACKUPMODULE"
-	mysqldump -R --add-drop-table -v --opt --lock-all-tables --log-error=$BACKUP_DIR/log/backup_$DATES.log -u $MYSQLROOTUSER -p$MYSQLROOTPASS $i | gzip > $BACKUP_DIR/mysql/$i.dmp.sql.gz
+	mysqldump --defaults-file=$MYSQLOPTIONSFILE -R --add-drop-table -v --opt --lock-all-tables --log-error=$BACKUP_DIR/log/backup_$DATES.log $i | gzip > $BACKUP_DIR/mysql/$i.dmp.sql.gz
 	rcCheck $?
 	sleep 10
 done

--- a/backupWeekly.sh
+++ b/backupWeekly.sh
@@ -100,11 +100,11 @@ if [ $backupMySQL -eq 1 ]
 then
 echo -n "Backing up mysql databases..."
 echo "Backing up  mysql databases..."  >> $BACKUP_DIR/log/backup_$DATES.log
-for i in `mysql -u$MYSQLROOTUSER -p$MYSQLROOTPASS -BNe 'select  schema_name from information_schema.schemata;'`
+for i in `mysql --defaults-file=$MYSQLOPTIONSFILE -BNe 'select  schema_name from information_schema.schemata;'`
 do 
 	BACKUPMODULE="mysql database schema $i"
         echo "Backing up $BACKUPMODULE"
-	mysqldump -R --add-drop-table -v --opt --lock-all-tables --log-error=$BACKUP_DIR/log/backup_$DATES.log -u $MYSQLROOTUSER -p$MYSQLROOTPASS $i | gzip > $BACKUP_DIR/mysql/$i.dmp.sql.gz
+	mysqldump --defaults-file=$MYSQLOPTIONSFILE -R --add-drop-table -v --opt --lock-all-tables --log-error=$BACKUP_DIR/log/backup_$DATES.log $i | gzip > $BACKUP_DIR/mysql/$i.dmp.sql.gz
 	rcCheck $?
 	sleep 10
 done


### PR DESCRIPTION
Removes the root user/pass from the configuration file and uses a
mysqloptions file https://dev.mysql.com/doc/refman/8.0/en/option-files.html

This prevents warnings from mysql about using a pssword on the command
line

Sample File make sure its not publicly readable, like your SSH keys.

```
[client]
user=root
password=your_password
```

Closes #14